### PR TITLE
[WIP] Virginia Dominion has implemented

### DIFF
--- a/_data/partners.yml
+++ b/_data/partners.yml
@@ -243,7 +243,7 @@
 - name: "Virginia Dominion Power"
   url: "https://www.dom.com/residential/dominion-virginia-power/"
   type: utility
-  status: committed
+  status: implemented
 - name: "Apogee Interactive, Inc."
   url: "http://www.Apogee.net"
   type: company


### PR DESCRIPTION
Move Virginia Dominion Power to the "implemented category." I'm leaving this pull request open to have a URL to point to for the issue, and as a place to provide supporting evidence of Dominion's support. Dominion says that they have provided support for two years, available to any customers who have signed for dynamic pricing, but they don't mention this anywhere on their website. (Apparently customers who have dynamic pricing do see it, but I am not such a customer, so I can't post a screenshot.)